### PR TITLE
fix: ensure irods env settings get priority

### DIFF
--- a/snakemake_storage_plugin_irods/__init__.py
+++ b/snakemake_storage_plugin_irods/__init__.py
@@ -33,7 +33,7 @@ from snakemake_interface_storage_plugins.storage_object import (
 from snakemake_interface_storage_plugins.io import IOCacheStorageInterface
 
 
-env_msg = "Will also be read from ~/.irods/irods_environment.json if present."
+env_msg = "Value in ~/.irods/irods_environment.json has higher priority, if present. "
 
 
 @dataclass
@@ -102,7 +102,7 @@ class StorageProviderSettings(StorageProviderSettingsBase):
                 env = json.load(f)
 
             def retrieve(src, trgt):
-                if getattr(self, trgt) is None:
+                if src in env:
                     setattr(self, trgt, env[src])
 
             retrieve("irods_host", "host")


### PR DESCRIPTION
Ensure that settings in ~/.irods/irods_environment.json have higher priority than default setting values, so that users don't have to copy settings from the environment file to the Snakefile.

(This is a proposed fix for issue #4)