### PR TITLE
build: Update python-irodsclient to 3.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ documentation = "https://snakemake.github.io/snakemake-plugin-catalog/plugins/st
 python = "^3.11"
 snakemake-interface-common = "^1.15.0"
 snakemake-interface-storage-plugins = "^3.0.0"
-python-irodsclient = "^1.1.9"
+python-irodsclient = "^3.0.0"
 
 [tool.poetry.group.dev.dependencies]
 black = "^23.12.0"


### PR DESCRIPTION
Based on https://github.com/irods/python-irodsclient/blob/v3.0.0/CHANGELOG.md, it seems like it ought to be possible to use the latest version of [`python-irodsclient`](https://pypi.org/project/python-irodsclient/).

I can’t test this, however, since I don’t have an iRODS server to connect to (and https://github.com/snakemake/snakemake/issues/2970 also prevents straightforward testing in a virtualenv).