### PR TITLE
feat!: switch from PRC to iBridges as the iRODS backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ documentation = "https://snakemake.github.io/snakemake-plugin-catalog/plugins/st
 python = "^3.11"
 snakemake-interface-common = "^1.15.0"
 snakemake-interface-storage-plugins = "^4.1.0"
-python-irodsclient = "^3.0.0"
+ibridges = "^1.5.0"
 
 [tool.poetry.group.dev.dependencies]
 black = "^23.12.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ documentation = "https://snakemake.github.io/snakemake-plugin-catalog/plugins/st
 python = "^3.11"
 snakemake-interface-common = "^1.15.0"
 snakemake-interface-storage-plugins = "^4.1.0"
-ibridges = "^1.5.0"
+ibridges = "^2.0"
 
 [tool.poetry.group.dev.dependencies]
 black = "^23.12.0"

--- a/snakemake_storage_plugin_irods/__init__.py
+++ b/snakemake_storage_plugin_irods/__init__.py
@@ -37,7 +37,7 @@ class ValueErrorParser():
     This ensures that errors normally passed to the argument parser, will be
     
     """
-    def error(msg: str):
+    def error(self, msg: str):
         raise ValueError(msg)
 
 def _non_interactive_auth(settings):

--- a/snakemake_storage_plugin_irods/__init__.py
+++ b/snakemake_storage_plugin_irods/__init__.py
@@ -118,9 +118,6 @@ class StorageProviderSettings(StorageProviderSettingsBase):
         }
     )
 
-utc = datetime.datetime.fromtimestamp(0, datetime.timezone.utc)
-
-
 # Required:
 # Implementation of your storage provider
 # This class can be empty as the one below.

--- a/snakemake_storage_plugin_irods/__init__.py
+++ b/snakemake_storage_plugin_irods/__init__.py
@@ -260,9 +260,11 @@ class StorageObject(StorageObjectRead, StorageObjectWrite, StorageObjectGlob):
 
     @retry_decorator
     def size(self) -> int:
-        # return the size in bytes
+        # Return the number of metadata items
         if self.metadata:
             return len(self.base_path.meta)
+
+        # return the size in bytes
         return self.path.size
 
     @retry_decorator

--- a/snakemake_storage_plugin_irods/__init__.py
+++ b/snakemake_storage_plugin_irods/__init__.py
@@ -310,13 +310,6 @@ class StorageObject(StorageObjectRead, StorageObjectWrite, StorageObjectGlob):
         return _find_matches(IrodsPath(self.provider.session, self.path),
                              self.path.parts)
 
-    def _convert_time(self, timestamp, tz=None):
-        dt = timestamp.replace(tzinfo=datetime.timezone("UTC"))
-        if tz:
-            dt = dt.astimezone(datetime.timezone(tz))
-        return dt
-
-
 def _next_wildcard(input_str: str) -> tuple[str, Optional[str]]:
     next_index = input_str.find("{")
     if next_index == -1:

--- a/snakemake_storage_plugin_irods/__init__.py
+++ b/snakemake_storage_plugin_irods/__init__.py
@@ -185,7 +185,6 @@ class StorageProvider(StorageProviderBase):
         # and considered valid. The wildcards will be resolved before the storage
         # object is actually used.
         parsed = urlparse(query)
-        # print(parsed.scheme, parsermd.path, parsed.netloc)
         if parsed.scheme == "irods" and parsed.path:
             return StorageQueryValidationResult(valid=True, query=query)
         else:

--- a/snakemake_storage_plugin_irods/__init__.py
+++ b/snakemake_storage_plugin_irods/__init__.py
@@ -238,20 +238,13 @@ class StorageObject(StorageObjectRead, StorageObjectWrite, StorageObjectGlob):
     def exists(self) -> bool:
         # TODO does this also work for collections?
         # return True if the object exists
-        print(self.path, self.metadata)
-        # print(self.base_path, self.base_path.exists())
         try:
             if self.metadata:
                 if not self.base_path.exists():
-                    print("Return", False)
                     return False
-                print("Return", len(self.base_path.meta) > 0)
                 return len(self.base_path.meta) > 0
-
-            print("Return", self.path.exists())
             return self.path.exists()
         except DoesNotExistError:
-            print("Return", self.path.exists())
             return False
 
     # def _data_obj(self):

--- a/snakemake_storage_plugin_irods/__init__.py
+++ b/snakemake_storage_plugin_irods/__init__.py
@@ -9,7 +9,8 @@ import json
 
 from ibridges.cli.config import IbridgesConf
 from ibridges import IrodsPath, download, upload, Session
-from ibridges.exception import DoesNotExistError, PasswordError
+from ibridges.exception import DoesNotExistError
+from ibridges.session import PasswordError
 from ibridges.interactive import DEFAULT_IRODSA_PATH
 
 from snakemake_interface_storage_plugins.settings import StorageProviderSettingsBase
@@ -184,7 +185,8 @@ class StorageProvider(StorageProviderBase):
         # and considered valid. The wildcards will be resolved before the storage
         # object is actually used.
         parsed = urlparse(query)
-        if parsed.scheme == "irods" and parsed.path and parsed.netloc:
+        # print(parsed.scheme, parsermd.path, parsed.netloc)
+        if parsed.scheme == "irods" and parsed.path:
             return StorageQueryValidationResult(valid=True, query=query)
         else:
             return StorageQueryValidationResult(
@@ -213,8 +215,9 @@ class StorageObject(StorageObjectRead, StorageObjectWrite, StorageObjectGlob):
         self.parsed_query = urlparse(self.query)
 
         # Determine the root, whether it's absolute or relative
-        root = "" if self.parsed_query.netloc in ["~", "."] else "/"
-        self.path = IrodsPath(self.provider.session, root, self.parsed_query.netloc,
+        # root = "" if self.parsed_query.netloc in ["~", "."] else "/"
+        netloc = self.parsed_query.netloc if self.parsed_query.netloc else "/"
+        self.path = IrodsPath(self.provider.session, netloc,
                               self.parsed_query.path.lstrip("/"))
 
         # Handle files with .metadata.json extensions differently.

--- a/snakemake_storage_plugin_irods/__init__.py
+++ b/snakemake_storage_plugin_irods/__init__.py
@@ -29,17 +29,17 @@ from snakemake_interface_storage_plugins.storage_object import (
 from snakemake_interface_storage_plugins.io import IOCacheStorageInterface
 
 
-# env_msg = "Will also be read from ~/.irods/irods_environment.json if present."
-METADATA_EXT=".metadata.json"
+METADATA_EXT = ".metadata.json"
 
 class ValueErrorParser():
     """For raising value errors instead of ArgumentParser errors.
-    
+
     IbridgesConf is a class normally used for the command line interface (CLI).
-    This ensures that errors normally passed to the argument parser, will be
-    
+    This ensures that errors normally passed to the argument parser, will be raised as ValueErrors instead.
+
     """
     def error(self, msg: str):
+        """Raise error message."""
         raise ValueError(msg)
 
 # Copied from python-irodsclient: client_init.py f700ab5
@@ -191,7 +191,8 @@ class StorageProvider(StorageProviderBase):
                 valid=False,
                 query=query,
                 reason="Query does not start with irods://, starts with irods:/// or does not "
-                "contain a path to a file or directory.",
+                "contain a path to a file or directory. Examples of valid queries: " 
+                "irods://an/absolute/path, irods://./a/relative/path, irods://~/a/relative/path/to/home.",
             )
 
 

--- a/snakemake_storage_plugin_irods/__init__.py
+++ b/snakemake_storage_plugin_irods/__init__.py
@@ -8,6 +8,7 @@ import json
 
 from ibridges.cli.util import cli_authenticate
 from ibridges import IrodsPath, download, upload
+from ibridges.exception import DoesNotExistError
 
 from snakemake_interface_storage_plugins.settings import StorageProviderSettingsBase
 from snakemake_interface_storage_plugins.storage_provider import (  # noqa: F401
@@ -237,11 +238,21 @@ class StorageObject(StorageObjectRead, StorageObjectWrite, StorageObjectGlob):
     def exists(self) -> bool:
         # TODO does this also work for collections?
         # return True if the object exists
-        if self.metadata:
-            if not self.base_path.exists():
-                return False
-            return len(self.base_path.meta) > 0
-        return self.path.exists()
+        print(self.path, self.metadata)
+        # print(self.base_path, self.base_path.exists())
+        try:
+            if self.metadata:
+                if not self.base_path.exists():
+                    print("Return", False)
+                    return False
+                print("Return", len(self.base_path.meta) > 0)
+                return len(self.base_path.meta) > 0
+
+            print("Return", self.path.exists())
+            return self.path.exists()
+        except DoesNotExistError:
+            print("Return", self.path.exists())
+            return False
 
     # def _data_obj(self):
         # return 

--- a/snakemake_storage_plugin_irods/__init__.py
+++ b/snakemake_storage_plugin_irods/__init__.py
@@ -294,7 +294,7 @@ class StorageObject(StorageObjectRead, StorageObjectWrite, StorageObjectGlob):
             with open(self.local_path(), "w") as handle:
                 json.dump(meta_dict["metadata"], handle)
         else:
-            download(self.provider.session, self.path, self.local_path())
+            download(self.path, self.local_path())
 
     # The following to methods are only required if the class inherits from
     # StorageObjectReadWrite.
@@ -309,7 +309,7 @@ class StorageObject(StorageObjectRead, StorageObjectWrite, StorageObjectGlob):
                 meta_dict = json.load(handle)
             self.base_path.meta.from_dict({"metadata": meta_dict})
         else:
-            upload(self.provider.session, self.local_path(), self.path, overwrite=True)
+            upload(self.local_path(), self.path, overwrite=True)
 
     @retry_decorator
     def remove(self):

--- a/snakemake_storage_plugin_irods/__init__.py
+++ b/snakemake_storage_plugin_irods/__init__.py
@@ -324,7 +324,7 @@ def _next_wildcard(input_str: str) -> tuple[str, Optional[str]]:
     if next_index < len(input_str)-1 and input_str[next_index+1] == "{":
         new_input_str, remaining_str = _next_wildcard(input_str[next_index+2:])
         return input_str[:next_index+2] + new_input_str, remaining_str
-    last_index = input_str.find("}")
+    last_index = input_str.find("}", next_index+1)
     if last_index == -1:
         raise ValueError(f"Bracket not closed properly in: {input_str}")
     return input_str[:next_index], input_str[last_index+1:]

--- a/snakemake_storage_plugin_irods/__init__.py
+++ b/snakemake_storage_plugin_irods/__init__.py
@@ -312,19 +312,19 @@ def _next_wildcard(input_str: str) -> tuple[str, Optional[str]]:
     if last_index == -1:
         raise ValueError(f"Bracket not closed properly in: {input_str}")
     return input_str[:next_index], input_str[last_index+1:]
-        
+
 
 def _find_matches(ipath: IrodsPath, remaining_parts: list[str]):# -> list[str]:
     if len(remaining_parts) == 0:
         if ipath.exists():
-            return [str(ipath)]
+            return ["irods:/" + str(ipath)]
         return []
-
 
     part = remaining_parts[0]
     new_ipath = ipath / part
     if re.match(r".*{.+}.*", part) is None:
         return _find_matches(new_ipath, remaining_parts[1:])
+
 
     if ipath.dataobject_exists() or not ipath.collection_exists():
         return []

--- a/snakemake_storage_plugin_irods/__init__.py
+++ b/snakemake_storage_plugin_irods/__init__.py
@@ -308,7 +308,7 @@ class StorageObject(StorageObjectRead, StorageObjectWrite, StorageObjectGlob):
         # Use snakemake_executor_plugins.io.get_constant_prefix(self.query) to get the
         # prefix of the query before the first wildcard.
         return _find_matches(IrodsPath(self.provider.session, self.path),
-                             self.path._path.parts)
+                             self.path.parts)
 
     def _convert_time(self, timestamp, tz=None):
         dt = timestamp.replace(tzinfo=datetime.timezone("UTC"))

--- a/snakemake_storage_plugin_irods/__init__.py
+++ b/snakemake_storage_plugin_irods/__init__.py
@@ -270,6 +270,9 @@ class StorageObject(StorageObjectRead, StorageObjectWrite, StorageObjectGlob):
 
     @retry_decorator
     def store_object(self):
+        if not self.path.parent.exists():
+            self.path.parent.create_collection(self.provider.session, self.path.parent)
+
         upload(self.provider.session, self.local_path(), self.path, overwrite=True)
 
 

--- a/snakemake_storage_plugin_irods/__init__.py
+++ b/snakemake_storage_plugin_irods/__init__.py
@@ -32,30 +32,6 @@ METADATA_EXT=".metadata.json"
 
 @dataclass
 class StorageProviderSettings(StorageProviderSettingsBase):
-    # host: Optional[str] = field(
-    #     default=None,
-    #     metadata={
-    #         "help": f"The host name of the iRODS server. {env_msg}",
-    #         "env_var": False,
-    #         "required": False,
-    #     },
-    # )
-    # port: Optional[int] = field(
-    #     default=None,
-    #     metadata={
-    #         "help": f"The port of the iRODS server. {env_msg}",
-    #         "env_var": False,
-    #         "required": False,
-    #     },
-    # )
-    # username: Optional[str] = field(
-    #     default=None,
-    #     metadata={
-    #         "help": f"The user name for the iRODS server. {env_msg}",
-    #         "env_var": True,
-    #         "required": False,
-    #     },
-    # )
     password: Optional[str] = field(
         default=None,
         metadata={
@@ -72,14 +48,7 @@ class StorageProviderSettings(StorageProviderSettingsBase):
             "required": False,
         }
     )
-    # zone: Optional[str] = field(
-    #     default=None,
-    #     metadata={
-    #         "help": f"The zone for the iRODS server. {env_msg}",
-    #         "env_var": False,
-    #         "required": False,
-    #     },
-    # )
+
     home: Optional[str] = field(
         default=None,
         metadata={
@@ -96,33 +65,6 @@ class StorageProviderSettings(StorageProviderSettingsBase):
             "required": False,
         }
     )
-    # authentication_scheme: str = field(
-    #     default="native",
-    #     metadata={
-    #         "help": f"The authentication scheme for the iRODS server. {env_msg}",
-    #         "env_var": False,
-    #         "required": False,
-    #     },
-    # )
-
-    # def __post_init__(self):
-    #     env_file = PosixPath(os.path.expanduser("~/.irods/irods_environment.json"))
-    #     if env_file.exists():
-    #         with open(env_file) as f:
-    #             env = json.load(f)
-
-    #         def retrieve(src, trgt):
-    #             if getattr(self, trgt) is None:
-    #                 setattr(self, trgt, env[src])
-
-    #         retrieve("irods_host", "host")
-    #         retrieve("irods_port", "port")
-    #         retrieve("irods_user_name", "username")
-    #         retrieve("irods_password", "password")
-    #         retrieve("irods_zone_name", "zone")
-    #         retrieve("irods_authentication_scheme", "authentication_scheme")
-    #         retrieve("irods_home", "home")
-
 
 utc = datetime.datetime.fromtimestamp(0, datetime.timezone.utc)
 

--- a/snakemake_storage_plugin_irods/__init__.py
+++ b/snakemake_storage_plugin_irods/__init__.py
@@ -325,8 +325,7 @@ class StorageObject(StorageObjectRead, StorageObjectWrite, StorageObjectGlob):
         # The method has to return concretized queries without any remaining wildcards.
         # Use snakemake_executor_plugins.io.get_constant_prefix(self.query) to get the
         # prefix of the query before the first wildcard.
-        return _find_matches(IrodsPath(self.provider.session, self.path),
-                             self.path.parts)
+        return _find_matches(self.path, self.path.parts)
 
 def _next_wildcard(input_str: str) -> tuple[str, Optional[str]]:
     next_index = input_str.find("{")

--- a/snakemake_storage_plugin_irods/__init__.py
+++ b/snakemake_storage_plugin_irods/__init__.py
@@ -168,7 +168,7 @@ class StorageProvider(StorageProviderBase):
         E.g. for a storage provider like http that would be the host name.
         For s3 it might be just the endpoint URL.
         """
-        return self.settings.host
+        return self.session.host
 
     def default_max_requests_per_second(self) -> float:
         """Return the default maximum number of requests per second for this storage
@@ -177,7 +177,7 @@ class StorageProvider(StorageProviderBase):
 
     def use_rate_limiter(self) -> bool:
         """Return False if no rate limiting is needed for this provider."""
-        return False
+        return True
 
     @classmethod
     def is_valid_query(cls, query: str) -> StorageQueryValidationResult:

--- a/snakemake_storage_plugin_irods/__init__.py
+++ b/snakemake_storage_plugin_irods/__init__.py
@@ -141,10 +141,10 @@ class StorageProvider(StorageProviderBase):
         # This is optional and can be removed if not needed.
         # Alternatively, you can e.g. prepare a connection to your storage backend here.
         # and set additional attributes.
-        if self.environment_file is not None:
-            self.session = Session(self.irods_environment, self.password, self.home, self.cwd)
+        if self.settings.environment_file is not None:
+            self.session = Session(self.settings.environment_file, self.settings.password, self.settings.home,
+                                   self.settings.cwd)
         else:
-            
             self.session = cli_authenticate(None)
 
     @classmethod

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -26,10 +26,4 @@ class TestStorage(TestStorageBase):
 
     def get_storage_provider_settings(self) -> Optional[StorageProviderSettingsBase]:
         # instantiate StorageProviderSettings of this plugin as appropriate
-        return StorageProviderSettings(
-            username="rods",
-            zone="tempZone",
-            host="localhost",
-            port=1247,
-            password="rods",
-        )
+        return StorageProviderSettings()


### PR DESCRIPTION
This PR moves the backend for iRODS to iBridges. This simplifies the plugin, since iBridges is built on the PRC and a little bit more high level. This PR also adds two feature to the storage plugin:

- Wildcards globbing is now supported. The implementation is not the most efficient, but it seems to work.
- There is now a way to add metadata as part of the workflow. This is done using the virtual file `{file}.metadata.json`. You can write to this virtual file using any method as a dictionary which will then automatically add metadata to the `{file}` dataobject or collection. This is kind of a hack, so perhaps should at least be marked as experimental, but I couldn't find another way to implement this sensibly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Metadata-file support for iRODS objects (.metadata.json) and metadata-aware operations.
  * Environment-file driven, non-interactive authentication.

* **Improvements**
  * Simplified storage configuration: removed low-level host/port/username/zone fields; added environment_file and cwd.
  * Broader wildcard/path discovery and improved path handling.
  * Increased default request rate limit and more reliable local path resolution.

* **Chores**
  * Tests updated to use default, empty storage settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->